### PR TITLE
Fix example implementation's  error by encapsulating in quotes

### DIFF
--- a/example/behat.yml
+++ b/example/behat.yml
@@ -9,7 +9,7 @@ default:
         - Drupal\DrupalExtension\Context\DrushContext
         - FeatureContext:
             parameters:
-              screenshot_dir: %paths.base%/screenshots
+              screenshot_dir: '%paths.base%/screenshots'
 
   extensions:
     Behat\MinkExtension:


### PR DESCRIPTION
Fixes the following:
$ ./run-behat

In Inline.php line 301:
                                                                                                                        
  The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 15 (near "screenshot_dir: %paths.base%/screenshots").