### PR TITLE
Fixed example features to work with new Bootstrap website

### DIFF
--- a/example/behat.yml
+++ b/example/behat.yml
@@ -14,18 +14,23 @@ default:
   extensions:
     Behat\MinkExtension:
       goutte: ~
-      selenium2: ~
       # Use goutte (basic PHP browser, super fast) as the default driver.
       default_session: goutte
       # For real browser testing and tests requiring JS use selenium2 driver.
-      # Tag features/scenarious with @javascript to use the selenium2 driver.
+      # Tag features/scenarios with @javascript to use the selenium2 driver.
       javascript_session: selenium2
       # Configure browser to be used. Browser must be available on wd_host.
       # Stick with chrome by default. It's 2x faster than firefox or phantomjs (your results may vary).
       browser_name: chrome
       selenium2:
         wd_host: http://browser:4444/wd/hub
-        capabilities: { "browser": "chrome", "version": "*" }
+        capabilities:
+          browser: "chrome"
+          version: "*"
+          marionette: true
+          extra_capabilities:
+            chromeOptions:
+              w3c: false
 
     Drupal\DrupalExtension:
       # Map template regions.

--- a/example/features/blackbox-javascript.feature
+++ b/example/features/blackbox-javascript.feature
@@ -7,7 +7,7 @@ Feature: Getbootstrap smoke testing
   Scenario: Open home page and find text
     Given I am on "http://getbootstrap.com/"
     #And the size is desktop
-    Then I should see text matching "Bootstrap is an open source toolkit for developing with HTML, CSS, and JS. Quickly prototype your ideas or build your entire app with our Sass variables and mixins, responsive grid system."
+    Then I should see text matching "Build fast, responsive sites with Bootstrap."
     When I follow "Get started"
     Then I should see text matching "Get started with Bootstrap"
     When I follow "Layout"

--- a/example/features/blackbox.feature
+++ b/example/features/blackbox.feature
@@ -5,7 +5,7 @@ Feature: Getbootstrap smoke testing
 
   Scenario: Open home page and find text
     Given I am on "http://getbootstrap.com/"
-    Then I should see text matching "Bootstrap is an open source toolkit for developing with HTML, CSS, and JS. Quickly prototype your ideas or build your entire app with our Sass variables and mixins, responsive grid system."
+    Then I should see text matching "Build fast, responsive sites with Bootstrap."
     When I follow "Get started"
     Then I should see text matching "Get started with Bootstrap"
     When I follow "Layout"


### PR DESCRIPTION
The Bootstrap website contains slightly different contents nowadays, which caused the example features to break. I also incorporated the proposed configuration changes from https://github.com/docksal/behat/issues/7 to make the Chrome driver work properly again.